### PR TITLE
Project card images: use object-cover over object-contain

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -36,7 +36,7 @@ const { title, description, tags, image, demoUrl, repoUrl, featured = false } = 
       <img
         src={image}
         alt={`Screenshot of ${title}`}
-        class="h-full w-full object-contain transition-transform duration-500 group-hover:scale-105"
+        class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
       />
     ) : (
       <div class="flex h-full w-full items-center justify-center text-zinc-600">


### PR DESCRIPTION
Fixes #3